### PR TITLE
ADD: CI/CD를 위한 profile추가 dev/prod #6  및 테이블설계오류 개선 #5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    
+
 
     implementation 'junit:junit:4.12'
     implementation 'net.rakugakibox.util:yaml-resource-bundle:1.1'

--- a/src/main/java/com/kindergarten/api/AppRunner.java
+++ b/src/main/java/com/kindergarten/api/AppRunner.java
@@ -1,0 +1,28 @@
+package com.kindergarten.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+
+@Component
+@Slf4j
+public class AppRunner implements ApplicationRunner {
+
+    @Autowired
+    ApplicationContext ctx;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        Environment environment =ctx.getEnvironment();
+        log.info("============활성화된 프로파일===============");
+        log.info(Arrays.toString(environment.getActiveProfiles()));
+        log.info("=======================================");
+    }
+}

--- a/src/main/java/com/kindergarten/api/common/result/CommonResult.java
+++ b/src/main/java/com/kindergarten/api/common/result/CommonResult.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 public class CommonResult {
     @ApiModelProperty(value = "응답 성공여부 : true/false")
     private boolean success;
-    @ApiModelProperty(value = "응답 코드 번호 : HTTP CODE")
+    @ApiModelProperty(value = "실패 응답 코드 번호 : HTTP CODE/성공시 0")
     private int code;
     @ApiModelProperty(value = "응답 메세지")
     private String msg;

--- a/src/main/java/com/kindergarten/api/common/result/ResponseService.java
+++ b/src/main/java/com/kindergarten/api/common/result/ResponseService.java
@@ -6,10 +6,9 @@ import java.util.List;
 
 @Service
 public class ResponseService {
-    // enum으로 api 요청 결과에 대한 code, message를 정의
+
     public enum CommonResponse {
-        SUCCESS(0, "성공하였습니디."),
-        FAIL(-1, "실패하였습니다.");
+        SUCCESS(0, "성공하였습니디.");
 
         int code;
         String msg;

--- a/src/main/java/com/kindergarten/api/controller/UserController.java
+++ b/src/main/java/com/kindergarten/api/controller/UserController.java
@@ -19,6 +19,7 @@ import javax.validation.Valid;
 @RequestMapping("/api/users")
 @EnableSwagger2
 @Slf4j
+@CrossOrigin(origins = "*")
 public class UserController {
 
     @Autowired
@@ -37,7 +38,11 @@ public class UserController {
     }
 
     @PostMapping("/parent")//회원가입
+
     public SingleResult<User> userSignUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+        System.out.println("======================");
+        System.out.println(signUpRequest.toString());
+        System.out.println("======================");
         log.debug("REST request to signup USER : {}", signUpRequest.getUserid());
         if (userRepository.existsByUserid(signUpRequest.getUserid())) {
             throw new CUserExistException();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,19 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/kinder
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    show-sql: true
+  messages:
+    basename: i18n/exception
+    encoding: UTF-8
+logging:
+  level:
+    root: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,17 @@
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/kinder
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    show-sql: true
+  messages:
+    basename: i18n/exception
+    encoding: UTF-8
+logging:
+  level:
+    root: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,16 +1,3 @@
 spring:
-  jwt:
-    secret:
-  h2:
-    console:
-      enabled: true
-  datasource:
-    url: jdbc:h2:tcp://localhost/~/kinder
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  jpa:
-    show-sql: true
-  messages:
-    basename: i18n/exception
-    encoding: UTF-8
+  profiles:
+    active: dev

--- a/src/test/java/com/kindergarten/api/controller/UserControllerTest.java
+++ b/src/test/java/com/kindergarten/api/controller/UserControllerTest.java
@@ -51,7 +51,7 @@ public class UserControllerTest {
     @Test
     public void 회원가입_성공() throws Exception {
         //given
-        final SignUpRequest dto = new SignUpRequest("test", "password", "이름", "01029159718", "test@test.com");
+        final SignUpRequest dto = new SignUpRequest("test", "password", "이름", "01012341234", "test@test.com");
 //        when
         final ResultActions resultActions = mockMvc.perform(post("/api/users/parent")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -70,7 +70,7 @@ public class UserControllerTest {
     @Test
     public void 회원가입_중복회원_실패() throws Exception {
         //given
-        final SignUpRequest dto = new SignUpRequest("test", "password", "이름", "01029159718", "test@test.com");
+        final SignUpRequest dto = new SignUpRequest("test", "password", "이름", "01012341234", "test@test.com");
         mockMvc.perform(post("/api/users/parent")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(dto)));
@@ -85,7 +85,6 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value(409))
                 .andExpect(jsonPath("$.msg").exists());
-
     }
 
 }


### PR DESCRIPTION
# PROFILE 추가
개발 시에는 h2 inmemory db를 사용하여 개발을 진행하고 배포환경에서는 다른 DB사용
- 개발용으로 사용하는 dev
- 배포용으로 사용하는 prod
# 테이블 오류개선

![스크린샷 2020-09-26 오전 3 44 22](https://user-images.githubusercontent.com/45715241/94304476-948ccc80-ffaa-11ea-87a7-f1b195285271.png)

- 기존 테이블은 학부모가 여러학생이 있을경우 각 학생별로 다른 유치원에 다니면 해당정보를 확인할 방법이 없었다.
- 여러명의 학생은 각각의 다른 1개의 유치원,어린이집에 다닐수 있다.
