### PR TITLE
회원가입시 중복회원 검사를 위한 API 추가 #2, JWT토큰을 통한 로그인 #10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+
+//    jwt token
     compile "io.jsonwebtoken:jjwt-api:0.11.1"
     compile "io.jsonwebtoken:jjwt-impl:0.11.1"
     compile "io.jsonwebtoken:jjwt-jackson:0.11.1"

--- a/src/main/java/com/kindergarten/api/common/reqeust/RequestLoginUser.java
+++ b/src/main/java/com/kindergarten/api/common/reqeust/RequestLoginUser.java
@@ -1,0 +1,16 @@
+package com.kindergarten.api.common.reqeust;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestLoginUser {
+    private String userid;
+    private String password;
+
+    public RequestLoginUser(String userid, String password) {
+        this.userid = userid;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/kindergarten/api/common/response/LoginResponse.java
+++ b/src/main/java/com/kindergarten/api/common/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.kindergarten.api.common.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginResponse {
+    private String response;
+    private String message;
+    private Object data;
+
+    public LoginResponse(String response, String message, Object data) {
+        this.response = response;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/kindergarten/api/common/result/ResponseService.java
+++ b/src/main/java/com/kindergarten/api/common/result/ResponseService.java
@@ -60,7 +60,6 @@ public class ResponseService {
     }
 
     // 결과 모델에 api 요청 성공 데이터를 세팅
-
     private void setSuccessResult(CommonResult result) {
         result.setSuccess(true);
         result.setCode(CommonResponse.SUCCESS.getCode());

--- a/src/main/java/com/kindergarten/api/controller/UserController.java
+++ b/src/main/java/com/kindergarten/api/controller/UserController.java
@@ -22,6 +22,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 
 @RestController
 @RequestMapping("/api/users")
@@ -51,8 +52,24 @@ public class UserController {
         return responseService.getListResult(userRepository.findAll());
     }
 
-    @PostMapping("/parent")//회원가입
+    @GetMapping("/existid/{userid}")
+    public SingleResult existuserId(@PathVariable String userid) {
+        Boolean existId = userRepository.existsByUserid(userid);
+        log.debug("==============================================");
+        log.debug(userid);
+        log.debug(String.valueOf(existId));
+        log.debug("==============================================");
+        SingleResult<Object> singleResult;
+        if (!existId) {
+            singleResult = responseService.getSingleResult("존재하지않는 ID입니다");
+        } else {
+            singleResult = responseService.getSingleResult("존재하는 ID입니다");
+        }
 
+        return singleResult;
+    }
+
+    @PostMapping("/parent")//회원가입
     public SingleResult<User> userSignUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         System.out.println("======================");
         System.out.println(signUpRequest.toString());

--- a/src/main/java/com/kindergarten/api/security/CookieUtil.java
+++ b/src/main/java/com/kindergarten/api/security/CookieUtil.java
@@ -1,0 +1,31 @@
+package com.kindergarten.api.security;
+
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+public class CookieUtil {
+
+    public Cookie createCookie(String cookieName, String value) {
+        Cookie token = new Cookie(cookieName, value);
+        token.setHttpOnly(true);
+        token.setMaxAge((int) JwtUtil.TOKEN_VALIDATION_SECOND);
+        token.setPath("/");
+        return token;
+    }
+
+    public Cookie getKooki(HttpServletRequest request, String cookieName) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(cookieName)) {
+                return cookie;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/kindergarten/api/security/JwtUtil.java
+++ b/src/main/java/com/kindergarten/api/security/JwtUtil.java
@@ -1,0 +1,14 @@
+package com.kindergarten.api.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public class JwtTokenProvider {
+
+    @Value("spring.jwt.secret")
+    private String secretKey;
+
+    private long tokenValidMillisecond = 1000L * 60 * 60;
+
+    private final UserDetailsService userDetailsService;
+}

--- a/src/main/java/com/kindergarten/api/security/JwtUtil.java
+++ b/src/main/java/com/kindergarten/api/security/JwtUtil.java
@@ -1,14 +1,82 @@
 package com.kindergarten.api.security;
 
+import com.kindergarten.api.model.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 
-public class JwtTokenProvider {
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
 
-    @Value("spring.jwt.secret")
-    private String secretKey;
+@Component
+public class JwtUtil {
 
-    private long tokenValidMillisecond = 1000L * 60 * 60;
+    public final static long TOKEN_VALIDATION_SECOND = 1000L * 10;
+    public final static long REFRESH_TOKEN_VALIDATION_SECOND = 1000L * 60 * 24 * 2;
 
-    private final UserDetailsService userDetailsService;
+    final static public String ACCESS_TOKEN_NAME = "accessToken";
+    final static public String REFRESH_TOKEN_NAME = "refreshToken";
+
+
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+
+
+    private Key getSigningKey(String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims extractAllClaims(String token) throws ExpiredJwtException {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(SECRET_KEY))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private String getUserid(String token) {
+        return extractAllClaims(token).get("userid", String.class);
+    }
+
+    public Boolean isTokenExpired(String token) {
+        final Date expiration = extractAllClaims(token).getExpiration();
+        return expiration.before(new Date());
+    }
+
+    public String generateToken(User user) {
+        return doGenerateToken(user.getUserid(), TOKEN_VALIDATION_SECOND);
+    }
+
+    public String generateRefreshToken(User user) {
+        return doGenerateToken(user.getUserid(), REFRESH_TOKEN_VALIDATION_SECOND);
+    }
+
+    public String doGenerateToken(String username, long expireTime) {
+
+        Claims claims = Jwts.claims();
+        claims.put("username", username);
+
+        String jwt = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expireTime))
+                .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS256)
+                .compact();
+
+        return jwt;
+    }
+
+    public Boolean validateToken(String token, UserDetails userDetails) {
+        final String userid = getUserid(token);
+
+        return (userid.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
 }

--- a/src/main/java/com/kindergarten/api/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/kindergarten/api/security/config/WebSecurityConfig.java
@@ -4,11 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 
+@EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
-
 
 
     @Override
@@ -19,15 +20,19 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable().authorizeRequests()
-                // 토큰을 활용하는 경우 모든 요청에 대해 접근이 가능하도록 함
-                .anyRequest().permitAll()
+        http.authorizeRequests().antMatchers("/h2").permitAll()
                 .and()
-                // session을 가지지 않는
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                // formlogin 비활성화
-                .formLogin()
-                .disable();
+                .csrf().disable()
+                .headers().frameOptions().disable();
+//                // 토큰을 활용하는 경우 모든 요청에 대해 접근이 가능하도록 함
+//                .anyRequest().permitAll()
+//                .and()
+//                // session을 가지지 않는
+//                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+//                .and()
+//                // formlogin 비활성화
+//                .formLogin()
+//                .disable();
+
     }
 }

--- a/src/main/java/com/kindergarten/api/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/kindergarten/api/security/config/WebSecurityConfig.java
@@ -1,0 +1,33 @@
+package com.kindergarten.api.security.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+//정적자원에 대해서는 security 미적용
+        web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable().authorizeRequests()
+                // 토큰을 활용하는 경우 모든 요청에 대해 접근이 가능하도록 함
+                .anyRequest().permitAll()
+                .and()
+                // session을 가지지 않는
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                // formlogin 비활성화
+                .formLogin()
+                .disable();
+    }
+}

--- a/src/main/java/com/kindergarten/api/service/Impl/UserDetailsImpl.java
+++ b/src/main/java/com/kindergarten/api/service/Impl/UserDetailsImpl.java
@@ -1,0 +1,46 @@
+package com.kindergarten.api.security;
+
+import com.kindergarten.api.model.entity.UserRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetailsImpl extends User {
+    public UserDetailsImpl(com.kindergarten.api.model.entity.User user) {
+        super(user.getUserid(), user.getPassword(), authorities(user));
+    }
+
+    private static Collection<? extends GrantedAuthority> authorities(com.kindergarten.api.model.entity.User user) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        if (user.getRole().equals(UserRole.ROLE_ADMIN)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_ADMIN.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_DIRECTOR)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_DIRECTOR.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_NOT_PERMITTED_DIRECTOR)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_NOT_PERMITTED_DIRECTOR.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_NOT_PERMITTED_TEACHER)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_NOT_PERMITTED_TEACHER.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_USER)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_USER.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_TEACHER)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_TEACHER.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_DIRECTOR)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_DIRECTOR.name()));
+        }
+        if (user.getRole().equals(UserRole.ROLE_ADMIN)) {
+            authorities.add(new SimpleGrantedAuthority(UserRole.ROLE_ADMIN.name()));
+        }
+        return authorities;
+    }
+
+}

--- a/src/main/java/com/kindergarten/api/service/Impl/UserDetailsImpl.java
+++ b/src/main/java/com/kindergarten/api/service/Impl/UserDetailsImpl.java
@@ -1,4 +1,4 @@
-package com.kindergarten.api.security;
+package com.kindergarten.api.service.Impl;
 
 import com.kindergarten.api.model.entity.UserRole;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,6 +13,7 @@ public class UserDetailsImpl extends User {
     public UserDetailsImpl(com.kindergarten.api.model.entity.User user) {
         super(user.getUserid(), user.getPassword(), authorities(user));
     }
+
 
     private static Collection<? extends GrantedAuthority> authorities(com.kindergarten.api.model.entity.User user) {
         List<GrantedAuthority> authorities = new ArrayList<>();

--- a/src/main/java/com/kindergarten/api/service/Impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/kindergarten/api/service/Impl/UserDetailsServiceImpl.java
@@ -1,0 +1,2 @@
+package com.kindergarten.api.service.Impl;public class UserDetailsServiceImpl {
+}

--- a/src/main/java/com/kindergarten/api/service/Impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/kindergarten/api/service/Impl/UserDetailsServiceImpl.java
@@ -1,2 +1,25 @@
-package com.kindergarten.api.service.Impl;public class UserDetailsServiceImpl {
+package com.kindergarten.api.service.Impl;
+
+import com.kindergarten.api.model.entity.User;
+import com.kindergarten.api.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+public class UserDetailsServiceImpl implements UserDetailsService {
+    @Autowired
+    UserRepository userRepository;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String userid) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findByUserid(userid);
+        if (user.isEmpty()) {
+            throw new UsernameNotFoundException(user.get().getUserid());
+        }
+        return new UserDetailsImpl(user.get());
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,9 @@ spring:
   h2:
     console:
       enabled: true
+      path: /h2
       settings:
+        trace: true
         web-allow-others: true
   datasource:
     url: jdbc:h2:mem:testdb

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   profiles:
     active: dev
+
+jwt:
+  secret: testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest


### PR DESCRIPTION
# 중복회원검사 기능
- 회원가입에 대한 정보를 post로 요청하면 중복된 아이디가 있으면 검사후 error를 발생하지만 가입전에도 id가 존재하는지 검사할수 있어야함

- GET: /api/users/existid/{userid} 요청 
- 회원이 존재하는 경우
<pre><code>{
    "success": true,
    "code": 0,
    "msg": "성공하였습니디.",
    "data": "존재하는 ID입니다"
}</code></pre>
- 회원이 존재하지 않는 경우
<pre><code>{
    "success": true,
    "code": 0,
    "msg": "성공하였습니디.",
    "data": "존재하지않는 ID입니다"
}</code></pre>

# 로그인시 토큰 발생
- userid와 password를 받아서 UserService의 loginUser메소드를 통해 데이터베이스에 저장된 암호화된 비밀번호와 파라미터를 검사
- 성공하면access token과 refresh token 2개 발급

### 참고자료
- https://velog.io/@tlatldms/%EC%84%9C%EB%B2%84%EA%B0%9C%EB%B0%9C%EC%BA%A0%ED%94%84-Refresh-JWT-%EA%B5%AC%ED%98%84

- https://tools.ietf.org/html/rfc6749#section-1.5