### PR TITLE
KinderGartensReposiotroy 테스트코드 추가 

### DIFF
--- a/src/main/java/com/kindergarten/api/student/StudentLogRepository.java
+++ b/src/main/java/com/kindergarten/api/student/StudentLogRepository.java
@@ -1,9 +1,11 @@
 package com.kindergarten.api.student;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface StudentLogRepository extends JpaRepository<StudentLog, Long> {
     Optional<StudentLog> findByStudents(Student student);
 }

--- a/src/main/java/com/kindergarten/api/student/StudentRepository.java
+++ b/src/main/java/com/kindergarten/api/student/StudentRepository.java
@@ -15,10 +15,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 
     boolean existsByUserAndKinderGartenAndAccessTrue(User user, KinderGarten kinderGarten);
 
-    boolean existsByUserAndAccessTrue(User user);
-
-    List<Student> findByUser(User user);
-
     List<Student> findByKinderGarten(KinderGarten kinderGarten);
 
 

--- a/src/test/java/com/kindergarten/api/kindergartens/KinderGartenRepositoryTest.java
+++ b/src/test/java/com/kindergarten/api/kindergartens/KinderGartenRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.kindergarten.api.kindergartens;
+
+import com.kindergarten.api.common.exception.CKinderGartenNotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+@ActiveProfiles("dev")
+public class KinderGartenRepositoryTest {
+    @Autowired
+    KinderGartenRepository kinderGartenRepository;
+
+
+    @Test
+    public void findByAddressContaining() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String address = "";
+        //when
+        Page<KinderGarten> byAddressContaining = kinderGartenRepository.findByAddressContaining(address, page);
+        //then
+        List<KinderGarten> content = byAddressContaining.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void findByAddressContainingAndIsKinderFalse() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String address = "";
+        //when
+        Page<KinderGarten> byAddressContainingAndIsKinderFalse = kinderGartenRepository.findByAddressContainingAndIsKinderFalse(address, page);
+        //then
+//        현재는 어린이집 데이터가 존재하지 않음
+        List<KinderGarten> content = byAddressContainingAndIsKinderFalse.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(0);
+
+    }
+
+    @Test
+    public void findByAddressContainingAndIsKinderTrue() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String address = "";
+        //when
+        Page<KinderGarten> byAddressContaining = kinderGartenRepository.findByAddressContainingAndIsKinderTrue(address, page);
+        //then
+        List<KinderGarten> content = byAddressContaining.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void findByNameContaining() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String name = "";
+        //when
+        Page<KinderGarten> byNameContaining = kinderGartenRepository.findByNameContaining(name, page);
+        //then
+        List<KinderGarten> content = byNameContaining.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void findByNameContainingAndIsKinderFalse() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String name = "";
+        //when
+        Page<KinderGarten> byNameContainingAndIsKinderFalse = kinderGartenRepository.findByNameContainingAndIsKinderFalse(name, page);
+        //then
+        List<KinderGarten> content = byNameContainingAndIsKinderFalse.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void findByNameContainingAndIsKinderTrue() {
+        //given
+        Pageable page = PageRequest.of(1, 10);
+        String name = "";
+        //when
+        Page<KinderGarten> byNameContainingAndIsKinderTrue = kinderGartenRepository.findByNameContainingAndIsKinderTrue(name, page);
+        //then
+        List<KinderGarten> content = byNameContainingAndIsKinderTrue.getContent();
+        Assertions.assertThat(content.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void findById() {
+        //given
+        Long kindergartensID = 1L;
+        //when
+        KinderGarten kinderGarten = kinderGartenRepository.findById(kindergartensID).orElseThrow(CKinderGartenNotFoundException::new);
+        Assertions.assertThat(kinderGarten.getId()).isEqualTo(kindergartensID);
+
+    }
+}

--- a/src/test/java/com/kindergarten/api/kindergartens/KinderGartenServiceTest.java
+++ b/src/test/java/com/kindergarten/api/kindergartens/KinderGartenServiceTest.java
@@ -1,10 +1,6 @@
-package com.kindergarten.api.service;
+package com.kindergarten.api.kindergartens;
 
 import com.kindergarten.api.common.exception.CKinderGartenNotFoundException;
-import com.kindergarten.api.kindergartens.KinderGarten;
-import com.kindergarten.api.kindergartens.KinderGartenDTO;
-import com.kindergarten.api.kindergartens.KinderGartenRepository;
-import com.kindergarten.api.kindergartens.KinderGartenService;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/kindergarten/api/reviews/comment/ReviewCommentServiceTest.java
+++ b/src/test/java/com/kindergarten/api/reviews/comment/ReviewCommentServiceTest.java
@@ -1,0 +1,7 @@
+package com.kindergarten.api.reviews.comment;
+
+import static org.junit.Assert.*;
+
+public class ReviewCommentServiceTest {
+
+}

--- a/src/test/java/com/kindergarten/api/student/StudentLogRepositoryTest.java
+++ b/src/test/java/com/kindergarten/api/student/StudentLogRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.kindergarten.api.student;
+
+import static org.junit.Assert.*;
+
+public class StudentLogRepositoryTest {
+
+}

--- a/src/test/java/com/kindergarten/api/student/StudentRepositoryTest.java
+++ b/src/test/java/com/kindergarten/api/student/StudentRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.kindergarten.api.student;
+
+import static org.junit.Assert.*;
+
+public class StudentRepositoryTest {
+
+}

--- a/src/test/java/com/kindergarten/api/student/StudentServiceTest.java
+++ b/src/test/java/com/kindergarten/api/student/StudentServiceTest.java
@@ -1,0 +1,7 @@
+package com.kindergarten.api.student;
+
+import static org.junit.Assert.*;
+
+public class StudentServiceTest {
+
+}

--- a/src/test/java/com/kindergarten/api/users/UserRepositoryTest.java
+++ b/src/test/java/com/kindergarten/api/users/UserRepositoryTest.java
@@ -1,7 +1,5 @@
-package com.kindergarten.api.repository;
+package com.kindergarten.api.users;
 
-import com.kindergarten.api.users.User;
-import com.kindergarten.api.users.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/com/kindergarten/api/users/UserServiceTest.java
+++ b/src/test/java/com/kindergarten/api/users/UserServiceTest.java
@@ -1,4 +1,4 @@
-package com.kindergarten.api.service;
+package com.kindergarten.api.users;
 
 import com.kindergarten.api.common.exception.CUserNotFoundException;
 import com.kindergarten.api.security.util.JwtTokenProvider;


### PR DESCRIPTION
# KinderGartensRepositoty 테스트코드 추가
#### 주소 및 이름으로 찾기
 - Pageable 객체를 통하여 페이징처리함
- 한페이지 사이즈를 10개를 하고 검색을 했을때 한페이지의 검색된 요소수가 10개가 맞는지 검사
- findByAddressContaining
    - 유치원,어린이집 주소로 검색
- findByAddressContainingAndIsKinderFalse
    - 어린이집 주소로검색
- findByAddressContainingAndIsKinderTrue
    - 유치원 주소로 검색
- findByNameContaining
    - 유치원, 어린이집 이름으로 검색
- findByNameContainingAndIsKinderFalse
    - 어린이집 이름으로 검색
- findByNameContainingAndIsKinderTrue
    - 유치원 이름으로 검색
#### index로 찾기
- index로 하나의 유치원정보를 가져옴
- index값을 주고 값을 준 index와 가져온 유치원의 index값을 비교
- findById
    - 유치원 index로 찾기